### PR TITLE
feat: added question comparing side-effect handlers (LaunchedEffect, SideEffect, DisposableEffect).

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,13 @@ this.lifecycleScope.launch {
 - What are the best practices for performance optimization in Jetpack Compose?
 - How is navigation handled in Jetpack Compose?
 - What is Strong Skipping Mode? [Answer](https://www.linkedin.com/posts/anandwana001_coding-datastructures-jetpackcompose-activity-7193437801365823488-SlVT?utm_source=share&utm_medium=member_desktop)
+- Compare and contrast `LaunchedEffect`, `SideEffect`, and `DisposableEffect`. Provide a clear use case for each one.
+  - `LaunchedEffect` is used to run a suspend function (coroutine) safely from a composable. It launches when the composable first enters the composition and cancels when it leaves. It will relaunch if its `key` parameter changes.
+  Use Case is to run a one-time suspend action when the composable first enters the composition, such as fetching initial data from a network or showing a `Snackbar`
+  - SideEffect is used to execute a block of code after every successful recomposition. It's an escape hatch to share Compose state with non-Compose code.
+  Use Case is to publish Compose state to non-Compose code, for example, updating an analytics library with the latest state value after every recomposition.
+  - `DisposableEffect` is similar to `LaunchedEffect` but provides a mandatory `onDispose` block for cleanup. The onDispose block is executed when the composable leaves the composition or when the `key` changes.
+  Use Case is to manage resources that require explicit cleanup, such as registering a `LifecycleObserver` and ensuring it's unregistered in the `onDispose` block to prevent memory leaks.
 
 
 ## Thread

--- a/README.md
+++ b/README.md
@@ -437,8 +437,9 @@ this.lifecycleScope.launch {
   Use Case is to run a one-time suspend action when the composable first enters the composition, such as fetching initial data from a network or showing a `Snackbar`
   - SideEffect is used to execute a block of code after every successful recomposition. It's an escape hatch to share Compose state with non-Compose code.
   Use Case is to publish Compose state to non-Compose code, for example, updating an analytics library with the latest state value after every recomposition.
-  - `DisposableEffect` is similar to `LaunchedEffect` but provides a mandatory `onDispose` block for cleanup. The onDispose block is executed when the composable leaves the composition or when the `key` changes.
-  Use Case is to manage resources that require explicit cleanup, such as registering a `LifecycleObserver` and ensuring it's unregistered in the `onDispose` block to prevent memory leaks.
+  - DisposableEffect is used for non-suspending side effects that require an explicit cleanup (teardown) process.
+  Unlike LaunchedEffect, the main effect block of DisposableEffect runs synchronously during composition. This block executes whenever the composable enters the Composition or when its given key(s) change. Its primary function is to provide a mandatory onDispose block for cleanup.
+  Use Case: Its primary use case is for managing listeners or observers from the Android framework that are not Compose-aware. For instance, registering a LifecycleObserver or a BroadcastReceiver inside the effect block, and then unregistering it within the mandatory onDispose block to prevent memory leaks.
 
 
 ## Thread


### PR DESCRIPTION
Hi there!

This PR contributes a set of new Android interview questions as part of the Hacktoberfest initiative.

I added a crucial new interview question to the list, focusing on side-effect handlers in Jetpack Compose (LaunchedEffect, SideEffect, and DisposableEffect).

## Changes Made
Added a new question: "Compare and contrast LaunchedEffect, SideEffect, and DisposableEffect. Provide a clear use case for each one."
Included a clear, structured answer highlighting the key differences in terms of lifecycle, use cases, and cleanup requirements.

Closes https://github.com/anandwana001/android-interview/issues/28

This question is important as it tests a candidate's understanding of how to manage asynchronous logic and lifecycle interactions within the declarative paradigm of Compose. This is a fundamental concept and a common point of confusion for many developers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Jetpack Compose guidance with clear comparisons of LaunchedEffect, SideEffect, and DisposableEffect, outlining when each runs, relation to composition, side-effect timing, and practical use cases.
  * Clarifies decision-making for choosing the appropriate effect in different scenarios.
  * No runtime or functional changes; documentation-only update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->